### PR TITLE
fix: rename group property to avoid HA entity group conflict in cover.py

### DIFF
--- a/custom_components/jarolift/cover.py
+++ b/custom_components/jarolift/cover.py
@@ -93,7 +93,7 @@ class JaroliftCover(CoverEntity):
         return self._name
 
     @property
-    def group(self):
+    def jarolift_group(self):
         """Return the name of the group if any."""
         return self._group
 


### PR DESCRIPTION
The property `group` was interpreted by Home Assistant as a group entity property, causing cover entities to be created with an unintended group assignment. Renamed to `jarolift_group` to avoid this naming conflict while preserving internal functionality.